### PR TITLE
GA4 — instrumentar conversões da Landing V5

### DIFF
--- a/analytics-v5.js
+++ b/analytics-v5.js
@@ -1,0 +1,110 @@
+(() => {
+  'use strict';
+
+  const send = (eventName, params = {}) => {
+    if (typeof window.gtag !== 'function') return;
+    window.gtag('event', eventName, params);
+  };
+
+  const path = window.location.pathname;
+  const fileName = path.split('/').pop() || '';
+  const moduleMap = {
+    'modulo-producao.html': 'producao',
+    'modulo-almoxarifado.html': 'almoxarifado',
+    'modulo-ativos.html': 'ativos_barris',
+    'modulo-comercial.html': 'comercial',
+    'modulo-logistica.html': 'logistica',
+    'modulo-financeiro.html': 'financeiro',
+    'modulo-brewpub.html': 'brewpub',
+    'modulo-fiscal.html': 'fiscal',
+    'modulo-pdv-mobile.html': 'pdv_mobile'
+  };
+
+  const moduleName = moduleMap[fileName];
+  if (moduleName) {
+    send('module_open', {
+      module_name: moduleName,
+      page_type: 'module'
+    });
+  }
+
+  const getLocation = (anchor) => {
+    if (anchor.closest('.header, .prod-header')) return 'header';
+    if (anchor.closest('.pricing, .price')) return 'pricing';
+    if (anchor.closest('.final-cta')) return 'final_cta';
+    if (anchor.closest('.story-section, .story')) return 'product_story';
+    if (anchor.closest('.modules, .modules-grid')) return 'modules_grid';
+    if (anchor.closest('footer, .footer')) return 'footer';
+    return moduleName ? 'module_body' : 'page_body';
+  };
+
+  document.addEventListener('click', (event) => {
+    const anchor = event.target.closest?.('a[href]');
+    if (!anchor) return;
+
+    const href = anchor.getAttribute('href') || '';
+    const location = getLocation(anchor);
+
+    if (/^https:\/\/app\.brewcontrol\.app\.br\/?/i.test(href)) {
+      const priceCard = anchor.closest('.price');
+      const planName = priceCard?.querySelector('h3')?.textContent?.trim().toLowerCase() || undefined;
+
+      send('app_open', {
+        cta_location: location,
+        page_type: moduleName ? 'module' : 'home',
+        ...(moduleName ? { module_name: moduleName } : {}),
+        ...(planName ? { plan_name: planName } : {})
+      });
+
+      if (planName) {
+        send('pricing_cta_click', {
+          plan_name: planName,
+          cta_location: 'pricing'
+        });
+      }
+      return;
+    }
+
+    if (/^https:\/\/wa\.me\/5527981848184/i.test(href) && anchor.closest('.final-cta')) {
+      send('founder_program_click', {
+        cta_location: 'final_cta'
+      });
+    }
+  }, { capture: true });
+
+  const observedVideos = new WeakSet();
+  const watchDemo = (video, demoKey) => {
+    if (!video || observedVideos.has(video)) return;
+    observedVideos.add(video);
+    let sent = false;
+
+    const mark = () => {
+      if (sent || video.paused || video.currentTime < 0.5) return;
+      sent = true;
+      send('demo_video_view', {
+        demo_key: demoKey || 'unknown',
+        page_type: moduleName ? 'module' : 'home',
+        ...(moduleName ? { module_name: moduleName } : {})
+      });
+    };
+
+    video.addEventListener('timeupdate', mark, { passive: true });
+  };
+
+  const scanRealDemos = () => {
+    document.querySelectorAll('[data-demo-key] video').forEach((video) => {
+      const host = video.closest('[data-demo-key]');
+      if (host?.classList.contains('video-ready')) watchDemo(video, host.dataset.demoKey);
+    });
+
+    document.querySelectorAll('[data-demo-cycle] video').forEach((video, index) => {
+      watchDemo(video, ['production', 'assets', 'commercial', 'brewpub'][index] || 'unknown');
+    });
+  };
+
+  scanRealDemos();
+  if ('MutationObserver' in window) {
+    const observer = new MutationObserver(scanRealDemos);
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+  }
+})();

--- a/landing-v5.js
+++ b/landing-v5.js
@@ -1,6 +1,14 @@
 (() => {
   'use strict';
 
+  if (!document.querySelector('script[data-brewcontrol-analytics]')) {
+    const analytics = document.createElement('script');
+    analytics.src = 'analytics-v5.js?v=20260907a';
+    analytics.async = false;
+    analytics.dataset.brewcontrolAnalytics = 'true';
+    document.head.appendChild(analytics);
+  }
+
   /* Small override sheet kept separate so the visual/performance pass is easy to review or revert. */
   if (!document.querySelector('link[data-v5-performance]')) {
     const perfStyles = document.createElement('link');

--- a/module-production-v5.js
+++ b/module-production-v5.js
@@ -1,6 +1,14 @@
 (() => {
   'use strict';
 
+  if (!document.querySelector('script[data-brewcontrol-analytics]')) {
+    const analytics = document.createElement('script');
+    analytics.src = 'analytics-v5.js?v=20260907a';
+    analytics.async = false;
+    analytics.dataset.brewcontrolAnalytics = 'true';
+    document.head.appendChild(analytics);
+  }
+
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const coarse = window.matchMedia('(pointer: coarse)').matches;
   const menu = document.querySelector('.menu');


### PR DESCRIPTION
Closes #3

## Objetivo
Adicionar eventos GA4 de intenção comercial sem coletar PII e sem alterar o layout da Landing V5.

## Eventos
- `app_open` — Entrar no app / Começar;
- `pricing_cta_click` — clique em CTA de plano, com `plan_name`;
- `module_open` — carregamento de página de módulo, com `module_name`;
- `founder_program_click` — CTA do Programa Cervejaria Fundadora;
- `demo_video_view` — só dispara quando um mini-demo real estiver disponível e tocar por mais de 0,5s.

## Privacidade
Os parâmetros são apenas contexto estático da interface (`cta_location`, `page_type`, `plan_name`, `module_name`, `demo_key`). Nenhum nome, e-mail, telefone, WhatsApp, cervejaria ou texto digitado é enviado.

## Implementação
- novo `analytics-v5.js` compartilhado;
- Home e páginas dos módulos carregam o tracker sem alterar HTML/visual;
- módulos compartilham o mesmo tracker por meio de `module-production-v5.js`.

## Validação
- branch está 3 commits à frente de `main`, sem divergência;
- diff limitado a 3 arquivos;
- `analytics-v5.js` passou em `node --check`;
- Preview Vercel `READY`;
- build sem erros.

## Pós-merge
Validar os eventos no GA4 Realtime/DebugView e depois marcar os eventos comerciais escolhidos como key events.