### PR TITLE
SEO Ops V1 — Sentinel técnico e runbook de agentes

### DIFF
--- a/.github/workflows/seo-sentinel.yml
+++ b/.github/workflows/seo-sentinel.yml
@@ -1,0 +1,117 @@
+name: SEO Sentinel
+
+on:
+  schedule:
+    - cron: '17 11 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: seo-sentinel
+  cancel-in-progress: false
+
+jobs:
+  technical-seo-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run SEO health check
+        id: audit
+        continue-on-error: true
+        run: node scripts/seo-health-check.mjs
+
+      - name: Upload SEO report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seo-health-report
+          path: |
+            seo-health-report.json
+            seo-health-report.md
+          retention-days: 30
+
+      - name: Open or update technical SEO alert
+        if: steps.audit.outcome == 'failure'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const title = '[SEO Sentinel] Regressão técnica';
+            const report = fs.readFileSync('seo-health-report.md', 'utf8');
+            const body = `${report}\n\n---\nGerado automaticamente pelo workflow \`SEO Sentinel\`. Corrija a causa; o alerta será fechado automaticamente quando o health-check voltar a PASS.`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const existing = issues.find((issue) => issue.title === title && !issue.pull_request);
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Nova falha detectada em ${new Date().toISOString()}. O corpo da Issue foi atualizado com o relatório mais recente.`
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['post-launch']
+              });
+            }
+
+      - name: Close recovered technical SEO alert
+        if: steps.audit.outcome == 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = '[SEO Sentinel] Regressão técnica';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const existing = issues.find((issue) => issue.title === title && !issue.pull_request);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `✅ Health-check voltou a PASS em ${new Date().toISOString()}. Fechando o alerta automaticamente.`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                state: 'closed'
+              });
+            }
+
+      - name: Fail workflow when audit failed
+        if: steps.audit.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/seo-sentinel.yml
+++ b/.github/workflows/seo-sentinel.yml
@@ -4,13 +4,18 @@ on:
   schedule:
     - cron: '17 11 * * *'
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/seo-sentinel.yml'
+      - 'scripts/seo-health-check.mjs'
+      - 'seo-ops.config.json'
 
 permissions:
   contents: read
   issues: write
 
 concurrency:
-  group: seo-sentinel
+  group: seo-sentinel-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -43,7 +48,7 @@ jobs:
           retention-days: 30
 
       - name: Open or update technical SEO alert
-        if: steps.audit.outcome == 'failure'
+        if: steps.audit.outcome == 'failure' && github.event_name != 'pull_request'
         uses: actions/github-script@v8
         with:
           script: |
@@ -84,7 +89,7 @@ jobs:
             }
 
       - name: Close recovered technical SEO alert
-        if: steps.audit.outcome == 'success'
+        if: steps.audit.outcome == 'success' && github.event_name != 'pull_request'
         uses: actions/github-script@v8
         with:
           script: |

--- a/SEO-OPS.md
+++ b/SEO-OPS.md
@@ -1,0 +1,154 @@
+# BrewControl SEO Ops
+
+Sistema operacional de SEO pós-lançamento da Landing V5.
+
+## Objetivo
+
+Aumentar descoberta orgânica e autoridade do BrewControl por meio de melhoria contínua baseada em dados reais. SEO Ops não tenta manipular ranking com tráfego falso, backlinks artificiais ou conteúdo em massa.
+
+## Componentes
+
+### 1. SEO Sentinel técnico
+
+Workflow: `.github/workflows/seo-sentinel.yml`
+
+Executa diariamente e também pode ser disparado manualmente. Não exige secrets externos.
+
+Valida:
+
+- HTTP 200 da Home e dos 9 módulos críticos;
+- canonical exato no host `www.brewcontrol.app.br`;
+- ausência de `noindex` acidental;
+- `robots.txt` acessível e apontando para o sitemap correto;
+- ausência de bloqueio genérico `User-agent: * / Disallow: /`;
+- sitemap contendo todas as URLs críticas;
+- `llms.txt` acessível e consistente com o host canônico.
+
+Em falha, abre ou atualiza uma única Issue chamada `[SEO Sentinel] Regressão técnica`. Quando tudo volta a PASS, fecha o alerta automaticamente.
+
+### 2. SEO Sentinel de dados
+
+Rotina recorrente no ChatGPT usando os conectores já configurados:
+
+- Google Search Console / GSC Wizard;
+- Bing Webmaster Tools;
+- Google Analytics 4.
+
+O Sentinel de dados deve alertar apenas quando houver evidência acionável. Não interpretar amostra mínima como regressão.
+
+Sinais principais:
+
+- indexação/cobertura de páginas críticas;
+- sitemap/crawl;
+- queda material de impressões ou cliques;
+- CTR anormal para a posição;
+- mudança relevante de posição;
+- erro de crawl no Bing;
+- tráfego orgânico e conversões no GA4.
+
+### 3. Opportunity Agent
+
+Rotina semanal que prioriza no máximo cinco oportunidades por ciclo.
+
+Analisa:
+
+- queries em posições 4–30;
+- queries com impressões e CTR abaixo do potencial;
+- page poaching / oportunidades próximas do topo;
+- ranking changes;
+- conteúdo em queda;
+- canibalização;
+- Search Console + GA4 por landing page;
+- Bing queries/pages;
+- clusters temáticos.
+
+A saída canônica é a Issue `SEO Opportunities — fila contínua`.
+
+O agente NÃO publica conteúdo automaticamente.
+
+### 4. Content Agent
+
+Só entra depois de uma oportunidade aprovada.
+
+Fluxo:
+
+1. oportunidade com evidência;
+2. intenção de busca;
+3. fontes e conhecimento operacional;
+4. briefing;
+5. rascunho;
+6. validação factual e de produto;
+7. branch/PR;
+8. publicação;
+9. sitemap/IndexNow;
+10. medição.
+
+### 5. Authority Agent
+
+Busca oportunidades legítimas de menções e links editoriais em entidades, fornecedores, escolas, eventos, podcasts, blogs e parceiros do setor.
+
+O agente pode pesquisar e preparar outreach, mas envio deve ser revisado/autorizado. Compra de links, diretórios em massa, comentários automáticos e redes artificiais são proibidos.
+
+### 6. AI Visibility
+
+Acompanhar, quando identificável, sessões e páginas referidas por ChatGPT, Perplexity, Copilot, Gemini, Claude e outros assistentes. Ausência de referrer não significa ausência de uso em IA.
+
+## Clusters canônicos
+
+Configurados no GSC Wizard em 07/09/2026:
+
+1. ERP e sistema para cervejaria;
+2. Produção e rastreabilidade;
+3. Barris, chopeiras e ativos;
+4. Estoque e insumos;
+5. Comercial e logística de chope;
+6. Brewpub e gestão financeira;
+7. Cervejaria cigana e terceirização.
+
+## Política de decisão
+
+Os thresholds iniciais estão em `seo-ops.config.json` e são heurísticos.
+
+Evitar mudanças por ranking quando:
+
+- a query tem amostra mínima;
+- a página acabou de ser publicada/indexada;
+- os dados ainda não estão consolidados;
+- a variação é pequena e não se repete.
+
+Priorizar quando houver volume e intenção suficientes, especialmente queries entre posições 4–30, CTR abaixo do potencial, queda material ou canibalização consistente.
+
+## Guardrails
+
+Nunca executar:
+
+- bots de clique ou buscas artificiais;
+- tráfego falso para CTR;
+- compra/criação automática de backlinks;
+- keyword stuffing;
+- páginas em massa com conteúdo raso;
+- reviews, clientes, números ou cases inventados;
+- publicação automática de conteúdo sem revisão factual;
+- secrets de Google/Bing versionados no repositório.
+
+## Baseline
+
+A Landing V5 foi publicada em 06/09/2026. Em 07/09, Search Console ainda tinha dados consolidados majoritariamente anteriores ao lançamento. A primeira comparação forte deve usar uma janela pós-V5 inteiramente consolidada.
+
+GA4 já confirmou em Tempo Real os eventos `module_open` e `app_open` após a instrumentação da V5.
+
+## Issues canônicas
+
+- `#13` — arquitetura SEO Ops;
+- `#14` — fila de oportunidades;
+- `#15` — fila de conteúdo;
+- `#16` — autoridade/backlinks reais;
+- `#17` — AI Visibility;
+- `#18` — baseline inicial.
+
+## Operação recomendada
+
+- diário: Sentinel técnico + Sentinel de dados;
+- semanal: Opportunity Agent;
+- mensal: revisão de clusters, conteúdo, autoridade e IA;
+- após qualquer mudança SEO relevante: registrar PR/data e aguardar janela suficiente antes de atribuir resultado.

--- a/scripts/seo-health-check.mjs
+++ b/scripts/seo-health-check.mjs
@@ -1,0 +1,148 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(here, '..', 'seo-ops.config.json');
+const config = JSON.parse(await readFile(configPath, 'utf8'));
+
+const report = {
+  checkedAt: new Date().toISOString(),
+  siteUrl: config.siteUrl,
+  status: 'pass',
+  checks: []
+};
+
+function record(name, ok, details) {
+  report.checks.push({ name, ok, details });
+  if (!ok) report.status = 'fail';
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    redirect: 'follow',
+    headers: {
+      'user-agent': 'BrewControl-SEO-Sentinel/1.0 (+https://www.brewcontrol.app.br/)'
+    }
+  });
+  return {
+    response,
+    text: await response.text()
+  };
+}
+
+function extractCanonical(html) {
+  const links = html.match(/<link\b[^>]*>/gi) || [];
+  for (const tag of links) {
+    if (!/\brel\s*=\s*["'][^"']*\bcanonical\b[^"']*["']/i.test(tag)) continue;
+    const href = tag.match(/\bhref\s*=\s*["']([^"']+)["']/i)?.[1];
+    if (href) return href;
+  }
+  return null;
+}
+
+function hasNoIndex(html, headers) {
+  const header = headers.get('x-robots-tag') || '';
+  if (/\bnoindex\b/i.test(header)) return `x-robots-tag=${header}`;
+
+  const metas = html.match(/<meta\b[^>]*>/gi) || [];
+  for (const tag of metas) {
+    const isRobots = /\bname\s*=\s*["'](?:robots|googlebot)["']/i.test(tag);
+    const content = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i)?.[1] || '';
+    if (isRobots && /\bnoindex\b/i.test(content)) return tag;
+  }
+  return null;
+}
+
+function expectedUrl(path) {
+  return new URL(path, `${config.siteUrl}/`).href;
+}
+
+for (const path of config.criticalPaths) {
+  const url = expectedUrl(path);
+  try {
+    const { response, text } = await fetchText(url);
+    record(`HTTP ${path}`, response.status === 200, `status=${response.status}; final=${response.url}`);
+
+    if (response.status !== 200) continue;
+
+    const canonical = extractCanonical(text);
+    record(
+      `Canonical ${path}`,
+      canonical === url,
+      canonical ? `expected=${url}; found=${canonical}` : `expected=${url}; canonical ausente`
+    );
+
+    const noindex = hasNoIndex(text, response.headers);
+    record(`Indexability ${path}`, !noindex, noindex || 'indexável');
+  } catch (error) {
+    record(`Fetch ${path}`, false, error instanceof Error ? error.message : String(error));
+  }
+}
+
+try {
+  const robotsUrl = expectedUrl(config.robotsPath);
+  const { response, text } = await fetchText(robotsUrl);
+  record('robots.txt HTTP', response.status === 200, `status=${response.status}`);
+
+  const expectedSitemap = `Sitemap: ${expectedUrl(config.sitemapPath)}`;
+  record('robots.txt sitemap', text.includes(expectedSitemap), `expected line: ${expectedSitemap}`);
+
+  const blocks = text.split(/(?=User-agent:)/i);
+  const generic = blocks.find((block) => /^User-agent:\s*\*/im.test(block));
+  const blocksAll = generic && /^\s*Disallow:\s*\/\s*(?:#.*)?$/im.test(generic);
+  record('robots.txt generic crawl', !blocksAll, blocksAll ? 'User-agent: * bloqueia /' : 'crawl genérico permitido');
+} catch (error) {
+  record('robots.txt fetch', false, error instanceof Error ? error.message : String(error));
+}
+
+try {
+  const sitemapUrl = expectedUrl(config.sitemapPath);
+  const { response, text } = await fetchText(sitemapUrl);
+  record('sitemap HTTP', response.status === 200, `status=${response.status}`);
+
+  const locations = new Set(
+    [...text.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/gi)].map((match) => match[1].trim())
+  );
+
+  for (const path of config.criticalPaths) {
+    const url = expectedUrl(path);
+    record(`Sitemap ${path}`, locations.has(url), locations.has(url) ? url : `URL ausente: ${url}`);
+  }
+} catch (error) {
+  record('sitemap fetch', false, error instanceof Error ? error.message : String(error));
+}
+
+try {
+  const llmsUrl = expectedUrl(config.llmsPath);
+  const { response, text } = await fetchText(llmsUrl);
+  record('llms.txt HTTP', response.status === 200, `status=${response.status}`);
+  record(
+    'llms.txt canonical host',
+    text.includes(config.canonicalHost),
+    text.includes(config.canonicalHost) ? config.canonicalHost : `host ausente: ${config.canonicalHost}`
+  );
+} catch (error) {
+  record('llms.txt fetch', false, error instanceof Error ? error.message : String(error));
+}
+
+const failures = report.checks.filter((check) => !check.ok);
+const lines = [
+  `# BrewControl SEO Sentinel`,
+  '',
+  `- **Status:** ${report.status === 'pass' ? 'PASS' : 'FAIL'}`,
+  `- **Checked at:** ${report.checkedAt}`,
+  `- **Site:** ${report.siteUrl}`,
+  `- **Checks:** ${report.checks.length}`,
+  `- **Failures:** ${failures.length}`,
+  '',
+  '## Checks',
+  '',
+  ...report.checks.map((check) => `- ${check.ok ? '✅' : '❌'} **${check.name}** — ${check.details}`)
+];
+
+await writeFile(resolve(here, '..', 'seo-health-report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+await writeFile(resolve(here, '..', 'seo-health-report.md'), `${lines.join('\n')}\n`, 'utf8');
+
+console.log(lines.join('\n'));
+if (report.status !== 'pass') process.exitCode = 1;

--- a/seo-ops.config.json
+++ b/seo-ops.config.json
@@ -1,0 +1,35 @@
+{
+  "siteUrl": "https://www.brewcontrol.app.br",
+  "canonicalHost": "www.brewcontrol.app.br",
+  "sitemapPath": "/sitemap.xml",
+  "robotsPath": "/robots.txt",
+  "llmsPath": "/llms.txt",
+  "criticalPaths": [
+    "/",
+    "/modulo-producao.html",
+    "/modulo-almoxarifado.html",
+    "/modulo-ativos.html",
+    "/modulo-comercial.html",
+    "/modulo-logistica.html",
+    "/modulo-financeiro.html",
+    "/modulo-brewpub.html",
+    "/modulo-fiscal.html",
+    "/modulo-pdv-mobile.html"
+  ],
+  "dataThresholds": {
+    "minimumImpressionsToAct": 20,
+    "opportunityPositionMin": 4,
+    "opportunityPositionMax": 30,
+    "materialClickDropPercent": 40,
+    "materialImpressionDropPercent": 50
+  },
+  "topicClusters": [
+    "ERP e sistema para cervejaria",
+    "Produção e rastreabilidade",
+    "Barris, chopeiras e ativos",
+    "Estoque e insumos",
+    "Comercial e logística de chope",
+    "Brewpub e gestão financeira",
+    "Cervejaria cigana e terceirização"
+  ]
+}


### PR DESCRIPTION
Closes #29

Implementa a primeira camada operacional do SEO Ops definido em #13.

## Incluído
- `seo-ops.config.json` com URLs críticas, thresholds iniciais e clusters;
- `scripts/seo-health-check.mjs` sem dependências externas;
- `.github/workflows/seo-sentinel.yml` diário + manual + validação em PR;
- `SEO-OPS.md` com arquitetura, ownership e guardrails.

## SEO Sentinel técnico
Valida Home + 9 módulos, HTTP 200, canonical `www`, noindex acidental, robots, sitemap e llms.txt. Em produção, usa uma única Issue de alerta e fecha automaticamente quando recuperar.

## Segurança/escopo
- nenhum secret Google/Bing no repositório;
- nenhuma mudança de runtime/layout da Landing V5;
- nenhum bot de clique, backlink automático ou publicação de conteúdo;
- GSC/Bing/GA4 continuam via conectores/rotinas de dados.

## Validação
O workflow roda também nesta PR; em `pull_request` ele valida o health-check mas não abre/fecha alertas automáticos.